### PR TITLE
add CRITERION_HAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Passthrough Module
 
-A [Hats Protocol](https://github.com/hats-protocol/hats-protocol) module that enables an authorized hat to serve as the eligibility and/or toggle module for other hat(s).
+A [Hats Protocol](https://github.com/hats-protocol/hats-protocol) module that enables an authorized "criterion" hat to serve as the eligibility and/or toggle module for other hat(s).
 
 ## Overview and Usage
 
@@ -14,13 +14,13 @@ This contract is a "humanistic" module, not a "mechanistic" module. It does not 
 
 To use Passthrough Module as the eligibility module for a target hat, set Passthrough Module's address as the target hat's eligibility address.
 
-Then, the wearer(s) of Passthrough Module's authorized hat can call the `PassthroughEligibility.setHatWearerStatus()` function — which is a thin wrapper around `Hats.setHatWearerStatus()` — to push eligibility data to Hats Protocol.
+Then, the wearer(s) of Passthrough Module's authorized `CRITERION_HAT` can call the `PassthroughEligibility.setHatWearerStatus()` function — which is a thin wrapper around `Hats.setHatWearerStatus()` — to push eligibility data to Hats Protocol.
 
 ### Passthrough Toggle
 
 To use Passthrough Module as the toggle module for a target hat, set Passthrough Module's address as the target hat's toggle address.
 
-Then, the wearer(s) of Passthrough Module's authorized hat can call the `PassthroughToggle.setHatWearerStatus()` function — which is a thin wrapper around `Hats.setHatWearerStatus()` — to push toggle data to Hats Protocol.
+Then, the wearer(s) of Passthrough Module's authorized `CRITERION_HAT` can call the `PassthroughToggle.setHatWearerStatus()` function — which is a thin wrapper around `Hats.setHatWearerStatus()` — to push toggle data to Hats Protocol.
 
 ## Development
 

--- a/src/PassthroughModule.sol
+++ b/src/PassthroughModule.sol
@@ -15,9 +15,9 @@ error NotAuthorized();
  * @title PassthroughModule
  * @author spengrah
  * @author Haberdasher Labs
- * @notice This module allows the wearer(s) of a given hat to serve as the eligibilty and/or toggle module for a
- * different hat. It effectively serves as an extension of a hat, enabling the hat itself to serve as the module even
- * though only addresses can be set as modules.
+ * @notice This module allows the wearer(s) of a given "criterion" hat to serve as the eligibilty and/or toggle module
+ * for a different hat. It effectively serves as an extension of a hat, enabling the hat itself to serve as the module
+ * even though only addresses can be set as modules.
  * @dev This contract inherits from HatsModule, and is intended to be deployed as minimal proxy clone(s) via
  * HatsModuleFactory. For this contract to be used, it must be set as either the eligibility or toggle module for
  * another hat.
@@ -45,8 +45,13 @@ contract PassthroughModule is HatsModule {
    * 0       | IMPLEMENTATION    | address | 20      | HatsModule          |
    * 20      | HATS              | address | 20      | HatsModule          |
    * 40      | hatId             | uint256 | 32      | HatsModule          |
+   * 72      | CRITERION_HAT     | uint256 | 32      | PassthroughModule   |
    * ----------------------------------------------------------------------+
    */
+
+  function CRITERION_HAT() public pure returns (uint256) {
+    return _getArgUint256(72);
+  }
 
   /*//////////////////////////////////////////////////////////////
                             CONSTRUCTOR
@@ -103,7 +108,7 @@ contract PassthroughModule is HatsModule {
 
   /// @notice Reverts if the caller is not wearing the {hatId} hat
   modifier onlyWearer() {
-    if (!HATS().isWearerOfHat(msg.sender, hatId())) revert NotAuthorized();
+    if (!HATS().isWearerOfHat(msg.sender, CRITERION_HAT())) revert NotAuthorized();
     _;
   }
 }

--- a/test/PassthroughModule.t.sol
+++ b/test/PassthroughModule.t.sol
@@ -69,12 +69,12 @@ contract WithInstanceTest is PassthroughModuleTest {
     vm.stopPrank();
 
     // we don't have any init args or immutable args
-    otherImmutableArgs;
+    otherImmutableArgs = abi.encodePacked(moduleHat);
     initArgs;
 
     // deploy an instance of the module
     instance =
-      PassthroughModule(deployModuleInstance(factory, address(implementation), moduleHat, otherImmutableArgs, initArgs));
+      PassthroughModule(deployModuleInstance(factory, address(implementation), 0, otherImmutableArgs, initArgs));
   }
 
   modifier caller_(address _caller) {
@@ -107,7 +107,11 @@ contract Deployment is WithInstanceTest {
   }
 
   function test_hatId() public {
-    assertEq(instance.hatId(), moduleHat);
+    assertEq(instance.hatId(), 0);
+  }
+
+  function test_criterionHat() public {
+    assertEq(instance.CRITERION_HAT(), moduleHat);
   }
 }
 


### PR DESCRIPTION
Refactor to use a new `CRITERION_HAT` instead of `hatId`, which can instead be set to the id of the hat on which the module is set or 0 if used with multiple hats.